### PR TITLE
Update for Swift 4.2

### DIFF
--- a/SODA iOS Sample/AppDelegate.swift
+++ b/SODA iOS Sample/AppDelegate.swift
@@ -1,3 +1,4 @@
+
 //
 //  AppDelegate.swift
 //  SODASample
@@ -13,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             
     var window: UIWindow?
         
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         return true
     }
 

--- a/SODA iOS Sample/MapViewController.swift
+++ b/SODA iOS Sample/MapViewController.swift
@@ -65,9 +65,9 @@ class MapViewController: UIViewController, MKMapViewDelegate {
         // Set the annotations and center the map
         if (anns.count > 0) {
             mapView.addAnnotations(anns)
-            let span = MKCoordinateSpanMake(maxLatitude - minLatitude, maxLongitude - minLongitude)
+            let span = MKCoordinateSpan.init(latitudeDelta: maxLatitude - minLatitude, longitudeDelta: maxLongitude - minLongitude)
             let center = CLLocationCoordinate2D(latitude: (maxLatitude + minLatitude)/2.0, longitude: (maxLongitude + minLongitude)/2.0)
-            let region = MKCoordinateRegionMake(center, span)
+            let region = MKCoordinateRegion.init(center: center, span: span)
 //            let r = MKCoordinateRegionMakeWithDistance(CLLocationCoordinate2D(latitude: lata*w, longitude: lona*w), 2000, 2000)
             mapView.setRegion(region, animated: animated)
         }

--- a/SODA iOS Sample/QueryViewController.swift
+++ b/SODA iOS Sample/QueryViewController.swift
@@ -23,14 +23,14 @@ class QueryViewController: UITableViewController {
 
         // Create a pull-to-refresh control
         refreshControl = UIRefreshControl ()
-        refreshControl?.addTarget(self, action: #selector(QueryViewController.refresh(_:)), for: UIControlEvents.valueChanged)
+        refreshControl?.addTarget(self, action: #selector(QueryViewController.refresh(_:)), for: UIControl.Event.valueChanged)
         
         // Auto-refresh
         refresh(self)
     }
     
     /// Asynchronous performs the data query then updates the UI
-    func refresh (_ sender: Any) {
+    @objc func refresh (_ sender: Any) {
 
         // there are about a dozen 1990 records in this particular database that have an incorrectly formatted
         // cad_event_number, so we'll filter them out to get most recent events first.
@@ -72,19 +72,19 @@ class QueryViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let c = tableView.dequeueReusableCell(withIdentifier: cellId) as UITableViewCell!
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellId)
         
         let item = data[indexPath.row]
         
         let name = item["event_clearance_description"]! as! String
-        c?.textLabel?.text = name
+        cell?.textLabel?.text = name
         
         let street = item["hundred_block_location"]! as! String
         let city = "Seattle"
         let state = "WA"
-        c?.detailTextLabel?.text = "\(street), \(city), \(state)"
+        cell?.detailTextLabel?.text = "\(street), \(city), \(state)"
         
-        return c!
+        return cell!
     }
 
     // MARK: - Navigation

--- a/SODAKit/SODAClient.swift
+++ b/SODAKit/SODAClient.swift
@@ -11,7 +11,7 @@ import Foundation
 // Reference: http://dev.socrata.com/consumers/getting-started.html
 
 /// The default number of items to return in SODAClient.queryDataset calls.
-let SODADefaultLimit = 1000
+public let SODADefaultLimit = 1000
 
 /// The result of an asynchronous SODAClient.queryDataset call. It can either succeed with data or fail with an error.
 public enum SODADatasetResult {

--- a/soda-swift.xcodeproj/project.pbxproj
+++ b/soda-swift.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2B5A59831EE231CD00EEC159 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2B5A59821EE231CD00EEC159 /* Info.plist */; };
 		2B5A59851EE247B900EEC159 /* EventDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5A59841EE247B900EEC159 /* EventDetailsViewController.swift */; };
 		2B5A59951EE3852200EEC159 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5A59921EE3852200EEC159 /* AppDelegate.swift */; };
 		2B5A59961EE3852200EEC159 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5A59931EE3852200EEC159 /* MapViewController.swift */; };
@@ -20,11 +19,6 @@
 		2D9E265019972FD20047C5C8 /* SODAClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9E264F19972FD20047C5C8 /* SODAClientTests.swift */; };
 		2D9E265A19972FEF0047C5C8 /* SODAClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9E265919972FEF0047C5C8 /* SODAClient.swift */; };
 		2D9E265B199736E90047C5C8 /* SODAClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9E265919972FEF0047C5C8 /* SODAClient.swift */; };
-		4FB082FC1E184136000814D0 /* Base.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4FB082F71E184136000814D0 /* Base.xcconfig */; };
-		4FB082FD1E184136000814D0 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4FB082F81E184136000814D0 /* Debug.xcconfig */; };
-		4FB082FE1E184136000814D0 /* Framework.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4FB082F91E184136000814D0 /* Framework.xcconfig */; };
-		4FB082FF1E184136000814D0 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4FB082FA1E184136000814D0 /* Release.xcconfig */; };
-		4FB083001E184136000814D0 /* Tests.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4FB082FB1E184136000814D0 /* Tests.xcconfig */; };
 		4FF1B2FF1E184C9F0066AB9D /* SODAClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9E265919972FEF0047C5C8 /* SODAClient.swift */; };
 /* End PBXBuildFile section */
 
@@ -278,11 +272,12 @@
 			attributes = {
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = Socrata;
 				TargetAttributes = {
 					2BA1422D1EE22FBC003DF54D = {
 						CreatedOnToolsVersion = 8.2.1;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 					2D9E263F19972FD10047C5C8 = {
@@ -326,7 +321,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B5A59831EE231CD00EEC159 /* Info.plist in Resources */,
 				2BA1423D1EE22FBC003DF54D /* LaunchScreen.storyboard in Resources */,
 				2BA1423A1EE22FBC003DF54D /* Assets.xcassets in Resources */,
 				2B5A599A1EE385FB00EEC159 /* Main.storyboard in Resources */,
@@ -337,11 +331,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4FB082FF1E184136000814D0 /* Release.xcconfig in Resources */,
-				4FB083001E184136000814D0 /* Tests.xcconfig in Resources */,
-				4FB082FD1E184136000814D0 /* Debug.xcconfig in Resources */,
-				4FB082FE1E184136000814D0 /* Framework.xcconfig in Resources */,
-				4FB082FC1E184136000814D0 /* Base.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -439,7 +428,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -457,7 +447,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.socrata.SODA-iOS-Sample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -473,14 +464,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -503,6 +502,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -518,14 +518,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -545,6 +553,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -554,6 +563,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4FB082F91E184136000814D0 /* Framework.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
 			};
@@ -563,6 +573,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4FB082F91E184136000814D0 /* Framework.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
 			};


### PR DESCRIPTION
Small updates for Swift 4.2 / XCode 10. Also set the @objc inference flag to Default for the Sample project to get rid of warnings.